### PR TITLE
 System.Text.Json instead of Newtosoft.Json

### DIFF
--- a/source/EventGenerator/EventGenerator/EventGenerator.csproj
+++ b/source/EventGenerator/EventGenerator/EventGenerator.csproj
@@ -17,6 +17,5 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Terminal.Gui" Version="1.10.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
GitHubTreeHandler now use System.Text.Json classes to avoid the use of Newtonsoft.Json external dependency